### PR TITLE
Fix TypeScript SDK README: setup, async main, pagination, error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,72 @@ API Documentation at https://sedaiengineering.github.io/sedai-sdk-python/
 
 Requires Node.js ≥ 16.
 
-Install the SDK:
+**1. Install**
 
     npm install https://github.com/SedaiEngineering/sedai-sdk-releases/raw/main/sedai-sdk-typescript-latest.tgz
 
-Configure and use:
+**2. TypeScript project setup**
+
+```bash
+npm install --save-dev typescript ts-node @types/node
+```
+
+Add a `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist"
+  }
+}
+```
+
+**3. Get an API token** — log in to your Sedai instance → Settings → API Keys → Create New Key
+
+**4. Use it**
+
+Create a file `exercise.ts`:
 
 ```typescript
-import { configure, getAllAccounts } from 'sedai-sdk';
+import { configure, getAllAccounts, getRecommendations, APIException } from 'sedai-sdk';
 
 configure({
   baseUrl: 'https://your-org.sedai.app',
   apiToken: 'your-api-token',
 });
 
-const accounts = await getAllAccounts();
+async function main() {
+  try {
+    // List accounts
+    const accounts = await getAllAccounts();
+    const accountId = accounts[0].id;
+    console.log('Account:', accounts[0].name, accountId);
+
+    // Key functions return a PageIterator<T> — iterate with for await
+    for await (const rec of getRecommendations({ accountIds: [accountId] })) {
+      console.log(rec.resourceId, rec.actionName);
+    }
+  } catch (e) {
+    if (e instanceof APIException) {
+      console.error('API error:', e.message);
+    } else {
+      throw e;
+    }
+  }
+}
+
+main();
 ```
 
-API Documentation at https://sedaiengineering.github.io/sedai-sdk-typescript/
+**5. Run**
+
+    npx ts-node exercise.ts
+
+**Full API reference** — type signatures, all functions, pagination, and examples:
+https://sedaiengineering.github.io/sedai-sdk-typescript/


### PR DESCRIPTION
Fixes all gaps found in engineer evaluation round 4.

- Top-level `await` replaced with `async function main()` — compiles correctly with `module: commonjs`
- TypeScript project setup added: tsconfig.json, dev deps, `npx ts-node` run command
- `for await` pagination example added with note that key functions return `PageIterator<T>`
- `try/catch` with `APIException` added to example
- TypeDoc link elevated as the primary full API reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)